### PR TITLE
Remove !important

### DIFF
--- a/src/ClipLoader.vue
+++ b/src/ClipLoader.vue
@@ -37,7 +37,7 @@ export default {
         borderStyle: 'solid',
         borderColor: this.color + ' ' + this.color + ' transparent',
         borderRadius: this.radius,
-        background: 'transparent !important'
+        background: 'transparent'
       }
     }
   }


### PR DESCRIPTION
In order to get rid of following warn, remove !important on background property.

```
[Vue warn]: It's probably a bad idea to use !important with inline rules. This feature will be deprecated in a future version of Vue.
```

It doesn't have any impact in final result, according to my tests.