### PR TITLE
Added the 'borderWidth' props for clip loader

### DIFF
--- a/src/ClipLoader.vue
+++ b/src/ClipLoader.vue
@@ -23,6 +23,10 @@ export default {
       type: String,
       default: '35px'
     },
+    borderWidth: {
+      type: String,
+      default: '2px'
+    },
     radius: {
       type: String,
       default: '100%'
@@ -33,7 +37,7 @@ export default {
       return {
         height: this.size,
         width: this.size,
-        borderWidth: '2px',
+        borderWidth: this.borderWidth,
         borderStyle: 'solid',
         borderColor: this.color + ' ' + this.color + ' transparent',
         borderRadius: this.radius,


### PR DESCRIPTION
Hi, i'm using this library well 👍 

When i enhanced the size to '50px', the spinner looks weird because of the thin borderWidth (fixed to 2px).
It must be cool, if added the 'borderWidth' props :D