### PR TITLE
Add WebKit (Safari) Readiness

### DIFF
--- a/src/ScaleLoader.vue
+++ b/src/ScaleLoader.vue
@@ -75,7 +75,6 @@ export default {
       }
     }
   }
-
 }
 </script>
 
@@ -88,13 +87,17 @@ export default {
     height: 40px;*/
     /*margin: 25px auto;*/
     text-align: center;
- 
 }
-
 
 @-webkit-keyframes v-scaleStretchDelay
 {
-    0%,
+    0%
+    {
+       -webkit-animation-name: inherit;
+       -webkit-animation-duration: inherit;
+       -webkit-animation-iteration-count: inherit;
+       -webkit-animation-direction: inherit;
+    },
     100%
     {
         -webkit-transform: scaleY(1);
@@ -109,7 +112,13 @@ export default {
 
 @keyframes v-scaleStretchDelay
 {
-    0%,
+    0%
+    {
+       -webkit-animation-name: inherit;
+       -webkit-animation-duration: inherit;
+       -webkit-animation-iteration-count: inherit;
+       -webkit-animation-direction: inherit;
+    },
     100%
     {
         -webkit-transform: scaleY(1);


### PR DESCRIPTION
Please accept this. Upon recent macOS with the Safari Web Browser, we have found that an animation of Scaleloader does not look like what we expected. I suppose that my fix will resolve this issue so that we can close [our issue](https://github.com/tokyo-metropolitan-gov/covid19/issues/4655). For your reference, you can see what the behavior we are facing with the Scaleloarder. Thank you in advance.